### PR TITLE
updated combine to retain cancellables and fixed alamo fire

### DIFF
--- a/Star Wars Contacts.xcodeproj/project.pbxproj
+++ b/Star Wars Contacts.xcodeproj/project.pbxproj
@@ -9,7 +9,6 @@
 /* Begin PBXBuildFile section */
 		273F1EDD22A84F5D00237A82 /* IndividualRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 273F1EDC22A84F5D00237A82 /* IndividualRow.swift */; };
 		273F1EDF22A862E900237A82 /* ImageStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 273F1EDE22A862E900237A82 /* ImageStore.swift */; };
-		273F1EE522A87B4700237A82 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 273F1EE422A87B4700237A82 /* Alamofire */; };
 		273F1EE822A8876F00237A82 /* DirectoryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 273F1EE722A8876F00237A82 /* DirectoryService.swift */; };
 		275A571922A8C93300BEB608 /* Injector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 275A571822A8C93300BEB608 /* Injector.swift */; };
 		27C397F722A7286500590E12 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27C397F622A7286500590E12 /* AppDelegate.swift */; };
@@ -31,10 +30,11 @@
 		27C3982822A846EC00590E12 /* FileManagerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27C3982722A846EC00590E12 /* FileManagerExtensions.swift */; };
 		27C3982A22A8476500590E12 /* individuals.json in Resources */ = {isa = PBXBuildFile; fileRef = 27C3982922A8476500590E12 /* individuals.json */; };
 		27C3982C22A8496B00590E12 /* PreviewDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27C3982B22A8496B00590E12 /* PreviewDatabase.swift */; };
-		27F75A8B22B2F5E3007713E1 /* Swinject in Frameworks */ = {isa = PBXBuildFile; productRef = 27F75A8A22B2F5E3007713E1 /* Swinject */; };
 		27FE714922B9A11200D852AE /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27FE714822B9A11200D852AE /* Theme.swift */; };
 		27FE714B22B9A3B400D852AE /* LabelDetailRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27FE714A22B9A3B400D852AE /* LabelDetailRow.swift */; };
 		27FE714D22B9B42A00D852AE /* NetworkLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27FE714C22B9B42A00D852AE /* NetworkLogger.swift */; };
+		FB7B2C352421770F003805B9 /* Swinject in Frameworks */ = {isa = PBXBuildFile; productRef = FB7B2C342421770F003805B9 /* Swinject */; };
+		FB7B2C3824217827003805B9 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = FB7B2C3724217827003805B9 /* Alamofire */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -74,8 +74,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				273F1EE522A87B4700237A82 /* Alamofire in Frameworks */,
-				27F75A8B22B2F5E3007713E1 /* Swinject in Frameworks */,
+				FB7B2C352421770F003805B9 /* Swinject in Frameworks */,
+				FB7B2C3824217827003805B9 /* Alamofire in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -206,8 +206,8 @@
 			);
 			name = "Star Wars Contacts";
 			packageProductDependencies = (
-				273F1EE422A87B4700237A82 /* Alamofire */,
-				27F75A8A22B2F5E3007713E1 /* Swinject */,
+				FB7B2C342421770F003805B9 /* Swinject */,
+				FB7B2C3724217827003805B9 /* Alamofire */,
 			);
 			productName = "Star Wars Contacts";
 			productReference = 27C397F322A7286500590E12 /* Star Wars Contacts.app */;
@@ -238,8 +238,8 @@
 			);
 			mainGroup = 27C397EA22A7286500590E12;
 			packageReferences = (
-				273F1EE322A87B4700237A82 /* XCRemoteSwiftPackageReference "Alamofire" */,
-				27F75A8922B2F5E3007713E1 /* XCRemoteSwiftPackageReference "Swinject" */,
+				FB7B2C332421770F003805B9 /* XCRemoteSwiftPackageReference "Swinject" */,
+				FB7B2C3624217827003805B9 /* XCRemoteSwiftPackageReference "Alamofire" */,
 			);
 			productRefGroup = 27C397F422A7286500590E12 /* Products */;
 			projectDirPath = "";
@@ -484,34 +484,34 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		273F1EE322A87B4700237A82 /* XCRemoteSwiftPackageReference "Alamofire" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/Alamofire/Alamofire.git";
-			requirement = {
-				branch = master;
-				kind = branch;
-			};
-		};
-		27F75A8922B2F5E3007713E1 /* XCRemoteSwiftPackageReference "Swinject" */ = {
+		FB7B2C332421770F003805B9 /* XCRemoteSwiftPackageReference "Swinject" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Swinject/Swinject.git";
 			requirement = {
-				branch = master;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.7.1;
+			};
+		};
+		FB7B2C3624217827003805B9 /* XCRemoteSwiftPackageReference "Alamofire" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Alamofire/Alamofire.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.4;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		273F1EE422A87B4700237A82 /* Alamofire */ = {
+		FB7B2C342421770F003805B9 /* Swinject */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 273F1EE322A87B4700237A82 /* XCRemoteSwiftPackageReference "Alamofire" */;
-			productName = Alamofire;
-		};
-		27F75A8A22B2F5E3007713E1 /* Swinject */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 27F75A8922B2F5E3007713E1 /* XCRemoteSwiftPackageReference "Swinject" */;
+			package = FB7B2C332421770F003805B9 /* XCRemoteSwiftPackageReference "Swinject" */;
 			productName = Swinject;
+		};
+		FB7B2C3724217827003805B9 /* Alamofire */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = FB7B2C3624217827003805B9 /* XCRemoteSwiftPackageReference "Alamofire" */;
+			productName = Alamofire;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Star Wars Contacts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Star Wars Contacts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,36 +5,18 @@
         "package": "Alamofire",
         "repositoryURL": "https://github.com/Alamofire/Alamofire.git",
         "state": {
-          "branch": "master",
-          "revision": "a516974f78d8c357e6ae47a92c6d7d8e98518b71",
-          "version": null
-        }
-      },
-      {
-        "package": "Nimble",
-        "repositoryURL": "https://github.com/Quick/Nimble",
-        "state": {
           "branch": null,
-          "revision": "f8657642dfdec9973efc79cc68bcef43a653a2bc",
-          "version": "8.0.2"
-        }
-      },
-      {
-        "package": "Quick",
-        "repositoryURL": "https://github.com/Quick/Quick",
-        "state": {
-          "branch": null,
-          "revision": "94df9b449508344667e5afc7e80f8bcbff1e4c37",
-          "version": "2.1.0"
+          "revision": "11928850d7273a8cd41bb766f2fc93b4d724b79b",
+          "version": "5.0.4"
         }
       },
       {
         "package": "Swinject",
         "repositoryURL": "https://github.com/Swinject/Swinject.git",
         "state": {
-          "branch": "master",
-          "revision": "317f44efc2441eaf8256b54fc099806432222211",
-          "version": null
+          "branch": null,
+          "revision": "8a76d2c74bafbb455763487cc6a08e91bad1f78b",
+          "version": "2.7.1"
         }
       }
     ]

--- a/Star Wars Contacts/Coordinators/AppCoordinator.swift
+++ b/Star Wars Contacts/Coordinators/AppCoordinator.swift
@@ -12,6 +12,9 @@ import Combine
 
 class AppCoordinator: Coordinator, CoordinatorProtocol {
     let window: UIWindow
+    
+    var cancellables = [String: AnyCancellable]()
+    
     init(window: UIWindow) {
         self.window = window
         super.init()
@@ -40,7 +43,7 @@ class AppCoordinator: Coordinator, CoordinatorProtocol {
     private func showListScreen() {
         let viewModel = IndividualListViewModel()
         viewModel.fetchItems()
-        _ = viewModel.didSelectedIndividual
+        cancellables["showList"] = viewModel.didSelectedIndividual
             .sink { [weak self] (item) in
             self?.showDetailScreen(item)
         }
@@ -55,7 +58,7 @@ class AppCoordinator: Coordinator, CoordinatorProtocol {
 
     private func showDetailScreen(_ item:IndividualModel) {
         let viewModel = IndividualDetailViewModel(model: item)
-        _ = viewModel.didNavigateBack
+        cancellables["detailBack"] = viewModel.didNavigateBack
             .sink { [weak self] in
             self?.navigationController.popViewController(animated: true)
         }

--- a/Star Wars Contacts/ViewModels/IndividualDetailViewModel.swift
+++ b/Star Wars Contacts/ViewModels/IndividualDetailViewModel.swift
@@ -6,13 +6,12 @@
 //  Copyright © 2019 Michael Holt. All rights reserved.
 //
 
-import protocol SwiftUI.BindableObject
+import protocol SwiftUI.ObservableObject
 import Foundation
 import Combine
 import CoreGraphics
 
-class IndividualDetailViewModel: BindableObject {
-    let willChange = PassthroughSubject<IndividualDetailViewModel, Never>()
+class IndividualDetailViewModel: ObservableObject {
     let didNavigateBack = PassthroughSubject<Void, Never>()
 
     let imageStore: ImageStoreProtocol
@@ -25,12 +24,7 @@ class IndividualDetailViewModel: BindableObject {
         self.directoryService = resolver.resolve()
     }
 
-    private(set) var error: Error? = nil {
-        didSet {
-            willChange.send(self)
-        }
-    }
-
+    @Published private(set) var error: Error? = nil
     var id: ID { model.id }
     var birthdate: Date { model.birthdate }
     var isForceSensitive: Bool { model.isForceSensitive }
@@ -57,8 +51,8 @@ class IndividualDetailViewModel: BindableObject {
     func handleImageDataResult(_ key:String, _ result:Result<Data, Error>) {
         switch result {
         case .success(let data):
+            self.objectWillChange.send()
             self.imageStore.addImage(for: key, data: data)
-            self.willChange.send(self)
         case .failure(let error):
             self.error = error
         }

--- a/Star Wars Contacts/ViewModels/IndividualListViewModel.swift
+++ b/Star Wars Contacts/ViewModels/IndividualListViewModel.swift
@@ -7,28 +7,18 @@
 //
 
 import Foundation
-import protocol SwiftUI.BindableObject
+import protocol SwiftUI.ObservableObject
 import Combine
 import CoreGraphics
 
-class IndividualListViewModel: BindableObject {
-    let willChange = PassthroughSubject<IndividualListViewModel, Never>()
+class IndividualListViewModel: ObservableObject {
     let didSelectedIndividual = PassthroughSubject<IndividualModel, Never>()
 
     let directoryService: DirectoryServiceProtocol
     let imageStore: ImageStoreProtocol
 
-    private(set) var items = [IndividualModel]() {
-        didSet {
-            willChange.send(self)
-        }
-    }
-
-    private(set) var error: Error? = nil {
-        didSet {
-            willChange.send(self)
-        }
-    }
+    @Published private(set) var items = [IndividualModel]()
+    @Published private(set) var error: Error? = nil
 
     init(items: [IndividualModel] = [], resolver: DependencyResolver = DependencyContainer.resolver) {
         self.items = items
@@ -58,8 +48,8 @@ class IndividualListViewModel: BindableObject {
     func handleImageDataResult(_ key:ImageID, _ result:Result<Data, Error>) {
         switch result {
         case .success(let data):
+            self.objectWillChange.send()
             self.imageStore.addImage(for: key, data: data)
-            self.willChange.send(self)
         case .failure(let error):
             self.error = error
         }

--- a/Star Wars Contacts/Views/IndividualListView.swift
+++ b/Star Wars Contacts/Views/IndividualListView.swift
@@ -12,7 +12,7 @@ struct IndividualListView: View {
     @EnvironmentObject var viewModel: IndividualListViewModel
     var body: some View {
         NavigationView {
-            List(viewModel.items.identified(by: \.id)) { item in
+            List(viewModel.items, id: \.id) { item in
                 Button(action: {
                     self.viewModel.selectItem(item: item)
                 }, label: {
@@ -25,7 +25,6 @@ struct IndividualListView: View {
             .navigationBarTitle(Text("Individuals"))
         }
     }
-
 }
 
 #if DEBUG


### PR DESCRIPTION
Hi there.  I found your example looking for how coordinator might be applied to swiftUI.  Interesting work!  
I found the project to be out of date and used it as an opportunity to learn some Combine.  First, the cancelable were being dropped so their subscriptions we not retained.  I added a dictionary to the coordinator to hang on to cancelable so that the closures would not be released.  I also updated the properties that were sending willChange.send through the  setter to use @Published property attribute.  No-one was subscribed to willChange so the send was not received.  That may have been an earlier pattern in Combine before BindableObject was replaced with ObservableObject.  

I also found some weird casting failure in AlamoFire and handled that.  You''ll see a conversion from one Result<> to another.  

Im not sure I fixed every issue but the project loads and the coordinators do their thing.  Images don't load on the list but that wasn't really critical to the demo.

Thanks for the sample.  Hope you find these updates helpful and keep the knowledge sharing!